### PR TITLE
[FEAT] 로그인/회원가입/인증인가

### DIFF
--- a/tobehomeserver/.gitignore
+++ b/tobehomeserver/.gitignore
@@ -37,3 +37,4 @@ out/
 .vscode/
 
 .DS_Store
+application-secret.properties

--- a/tobehomeserver/build.gradle
+++ b/tobehomeserver/build.gradle
@@ -35,6 +35,11 @@ dependencies {
 	testImplementation("org.junit.vintage:junit-vintage-engine") {
 		exclude group: "org.hamcrest", module: "hamcrest-core"
 	}
+
+	// JWT 토큰
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
 }
 
 tasks.named('test') {

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/TobehomeserverApplication.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/TobehomeserverApplication.java
@@ -2,8 +2,9 @@ package com.tobehome.tobehomeserver;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = {SecurityAutoConfiguration.class})
 public class TobehomeserverApplication {
 
 	public static void main(String[] args) {

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/BCryptConfig.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/BCryptConfig.java
@@ -1,0 +1,16 @@
+package com.tobehome.tobehomeserver.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+public class BCryptConfig {
+
+    // 비밀번호를 암호화 해주는 BCryptPasswordEncoder
+    @Bean   // 비밀번호 암호화, 비밀번호 체크할 때 사용
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/BCryptConfig.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/BCryptConfig.java
@@ -7,7 +7,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 @Configuration
 public class BCryptConfig {
 
-    // 비밀번호를 암호화 해주는 BCryptPasswordEncoder
     @Bean   // 비밀번호 암호화, 비밀번호 체크할 때 사용
     public BCryptPasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/JpaAuditingConfig.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.tobehome.tobehomeserver.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/PropertyConfig.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/PropertyConfig.java
@@ -4,6 +4,5 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 
 @Configuration
-@PropertySource("classpath:/.env")
 public class PropertyConfig {
 }

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/PropertyConfig.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/PropertyConfig.java
@@ -4,5 +4,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 
 @Configuration
+//@PropertySource("classpath:application-secret.properties")
 public class PropertyConfig {
 }

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/PropertyConfig.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/PropertyConfig.java
@@ -1,0 +1,9 @@
+package com.tobehome.tobehomeserver.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+@Configuration
+@PropertySource("classpath:/.env")
+public class PropertyConfig {
+}

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/SecurityConfig.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/SecurityConfig.java
@@ -30,7 +30,7 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
                 .csrf(AbstractHttpConfigurer::disable)  // 실제 운영 환경에서는 활성화하는 걸 권장
-//                .httpBasic(AbstractHttpConfigurer::disable) // HTTP 기본 인증 비활성화(사용자 이름과 비밀번호를 평문으로 전송하기 때문에 보안에 취약)
+                .httpBasic(AbstractHttpConfigurer::disable) // HTTP 기본 인증 비활성화(사용자 이름과 비밀번호를 평문으로 전송하기 때문에 보안에 취약)
 //                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션을 사용하지 않기 때문에 STATELESS로 설정
                 .exceptionHandling(exception -> exception.authenticationEntryPoint(jwtAuthenticationEntryPoint)) // 인증되지 않은 사용자의 접근에 대해 401 Unauthorized 에러를 리턴하는 클래스
                 //api 경로

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/SecurityConfig.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.tobehome.tobehomeserver.config;
 
+import com.tobehome.tobehomeserver.config.jwt.CustomJwtAuthenticationEntryPoint;
+import com.tobehome.tobehomeserver.config.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -28,12 +30,14 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
                 .csrf(AbstractHttpConfigurer::disable)  // 실제 운영 환경에서는 활성화하는 걸 권장
-                .httpBasic(AbstractHttpConfigurer::disable) // HTTP 기본 인증 비활성화(사용자 이름과 비밀번호를 평문으로 전송하기 때문에 보안에 취약)
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션을 사용하지 않기 때문에 STATELESS로 설정
+//                .httpBasic(AbstractHttpConfigurer::disable) // HTTP 기본 인증 비활성화(사용자 이름과 비밀번호를 평문으로 전송하기 때문에 보안에 취약)
+//                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션을 사용하지 않기 때문에 STATELESS로 설정
                 .exceptionHandling(exception -> exception.authenticationEntryPoint(jwtAuthenticationEntryPoint)) // 인증되지 않은 사용자의 접근에 대해 401 Unauthorized 에러를 리턴하는 클래스
+                //api 경로
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers(new AntPathRequestMatcher("/api/auth/**")).permitAll()
-                        .anyRequest().authenticated()) // 인증이 필요한 경로 설정
+                        .requestMatchers(new AntPathRequestMatcher("/signup")).permitAll()
+                        .requestMatchers(new AntPathRequestMatcher("/login")).permitAll()
+                        .anyRequest().authenticated()) // 나머지 경로는 jwt 인증 해야함
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class) // JWT를 통해 인증된 사용자를 식별하는 필터
                 .build();
     }

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/SecurityConfig.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/SecurityConfig.java
@@ -1,0 +1,83 @@
+package com.tobehome.tobehomeserver.config;
+
+import com.tobehome.tobehomeserver.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import static org.springframework.boot.autoconfigure.security.servlet.PathRequest.toH2Console;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final MemberService memberService;
+
+    @Bean   // Spring Security 기능(인증, 인가) 비활성화
+    public WebSecurityCustomizer configure() {
+        return (web) -> web.ignoring()
+                .requestMatchers(toH2Console())
+                .requestMatchers("/static/**");
+    }
+
+    @Bean   // 특정 HTTP 요청에 대한 웹 기반 보안 구성. (인증인가, 로그인, 로그아웃 설정)
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeRequests(authorize -> authorize
+                        .requestMatchers("/login", "/signup").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .formLogin(login -> login
+                        .loginPage("/login").defaultSuccessUrl("/")
+                )
+                .logout(logout ->
+                        logout.logoutSuccessUrl("/").invalidateHttpSession(true)
+                )
+                .csrf(AbstractHttpConfigurer::disable)
+                .headers(headers -> headers.frameOptions(FrameOptionsConfig::sameOrigin));
+
+        return http.build();
+    }
+
+    @Bean   // CORS 설정
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                        .allowedOrigins("*")
+                        .allowedOriginPatterns("*")
+                        .allowedMethods("*");
+            }
+        };
+    }
+
+    @Bean   // 인증 관리자 관련 설정
+    @Lazy
+    public DaoAuthenticationProvider daoAuthenticationProvider() throws Exception {
+        DaoAuthenticationProvider daoAuthenticationProvider = new DaoAuthenticationProvider();
+
+        daoAuthenticationProvider.setUserDetailsService(memberService);
+        daoAuthenticationProvider.setPasswordEncoder(bCryptPasswordEncoder());
+
+        return daoAuthenticationProvider;
+    }
+
+    @Bean   // 패스워드 인코더로 사용할 빈 등록
+    @Lazy
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/SecurityConfig.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/SecurityConfig.java
@@ -1,83 +1,46 @@
 package com.tobehome.tobehomeserver.config;
 
-import com.tobehome.tobehomeserver.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Lazy;
-import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-import static org.springframework.boot.autoconfigure.security.servlet.PathRequest.toH2Console;
+import static org.springframework.security.config.Customizer.withDefaults;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    private final MemberService memberService;
 
-    @Bean   // Spring Security 기능(인증, 인가) 비활성화
-    public WebSecurityCustomizer configure() {
-        return (web) -> web.ignoring()
-                .requestMatchers(toH2Console())
-                .requestMatchers("/static/**");
-    }
+//    @Bean   // Spring Security 기능(인증, 인가) 비활성화
+//    public WebSecurityCustomizer configure() {
+//        return (web) -> web.ignoring()
+//                .requestMatchers(toH2Console())
+//                .requestMatchers("/static/**");
+//    }
 
     @Bean   // 특정 HTTP 요청에 대한 웹 기반 보안 구성. (인증인가, 로그인, 로그아웃 설정)
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http
-                .authorizeRequests(authorize -> authorize
-                        .requestMatchers("/login", "/signup").permitAll()
-                        .anyRequest().authenticated()
-                )
-                .formLogin(login -> login
-                        .loginPage("/login").defaultSuccessUrl("/")
-                )
-                .logout(logout ->
-                        logout.logoutSuccessUrl("/").invalidateHttpSession(true)
-                )
-                .csrf(AbstractHttpConfigurer::disable)
-                .headers(headers -> headers.frameOptions(FrameOptionsConfig::sameOrigin));
+//        http
+//                .authorizeRequests(authorize -> authorize
+//                        .requestMatchers("/login", "/signup").permitAll()
+//                        .anyRequest().authenticated()
+//                )
+//                .formLogin(login -> login
+//                        .loginPage("/login").defaultSuccessUrl("/")
+//                )
+//                .logout(logout ->
+//                        logout.logoutSuccessUrl("/").invalidateHttpSession(true)
+//                )
+//                .csrf(AbstractHttpConfigurer::disable)
+//                .headers(headers -> headers.frameOptions(FrameOptionsConfig::sameOrigin));
+        http.authorizeHttpRequests((authz) -> authz.anyRequest().authenticated())
+                .httpBasic(withDefaults());
 
         return http.build();
     }
 
-    @Bean   // CORS 설정
-    public WebMvcConfigurer corsConfigurer() {
-        return new WebMvcConfigurer() {
-            @Override
-            public void addCorsMappings(CorsRegistry registry) {
-                registry.addMapping("/**")
-                        .allowedOrigins("*")
-                        .allowedOriginPatterns("*")
-                        .allowedMethods("*");
-            }
-        };
-    }
-
-    @Bean   // 인증 관리자 관련 설정
-    @Lazy
-    public DaoAuthenticationProvider daoAuthenticationProvider() throws Exception {
-        DaoAuthenticationProvider daoAuthenticationProvider = new DaoAuthenticationProvider();
-
-        daoAuthenticationProvider.setUserDetailsService(memberService);
-        daoAuthenticationProvider.setPasswordEncoder(bCryptPasswordEncoder());
-
-        return daoAuthenticationProvider;
-    }
-
-    @Bean   // 패스워드 인코더로 사용할 빈 등록
-    @Lazy
-    public BCryptPasswordEncoder bCryptPasswordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
 }

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/SecurityConfig.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/SecurityConfig.java
@@ -27,25 +27,46 @@ public class SecurityConfig {
 
     @Bean   // 특정 HTTP 요청에 대한 웹 기반 보안 구성. (인증인가, 로그인, 로그아웃 설정)
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        return http
-                .csrf(AbstractHttpConfigurer::disable)  // 실제 운영 환경에서는 활성화하는 걸 권장
-                .httpBasic(AbstractHttpConfigurer::disable) // HTTP 기본 인증 비활성화(사용자 이름과 비밀번호를 평문으로 전송하기 때문에 보안에 취약)
+//        return http
+//                .csrf(AbstractHttpConfigurer::disable)  // 실제 운영 환경에서는 활성화하는 걸 권장
+//                .httpBasic(AbstractHttpConfigurer::disable) // HTTP 기본 인증 비활성화(사용자 이름과 비밀번호를 평문으로 전송하기 때문에 보안에 취약)
+//
+//                // 세션을 사용하지 않기 때문에 STATELESS로 설정
+//                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+//
+//                // 인증되지 않은 사용자의 접근에 대해 401 Unauthorized 에러를 리턴하는 클래스
+//                .exceptionHandling(exception -> exception.authenticationEntryPoint(jwtAuthenticationEntryPoint))
+//
+//                //api 경로
+//                .authorizeHttpRequests(authorize -> authorize
+//                        .requestMatchers(new AntPathRequestMatcher("/signup")).permitAll()
+//                        .requestMatchers(new AntPathRequestMatcher("/login")).permitAll()
+//                        .requestMatchers(new AntPathRequestMatcher("/")).permitAll()
+////                        .requestMatchers("/admin/**").hasRole("ADMIN")
+//                        .anyRequest().authenticated()) // 나머지 경로는 jwt 인증 해야함
+//                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class) // JWT를 통해 인증된 사용자를 식별하는 필터
+//                .build();
+
+        http.cors().and()
+                .csrf().disable() // 실제 운영 환경에서는 활성화하는 걸 권장
+                .httpBasic().disable() // HTTP 기본 인증 비활성화(사용자 이름과 비밀번호를 평문으로 전송하기 때문에 보안에 취약)
 
                 // 세션을 사용하지 않기 때문에 STATELESS로 설정
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
 
                 // 인증되지 않은 사용자의 접근에 대해 401 Unauthorized 에러를 리턴하는 클래스
-                .exceptionHandling(exception -> exception.authenticationEntryPoint(jwtAuthenticationEntryPoint))
+                .exceptionHandling().authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                .and()
+                .authorizeRequests()
+                .requestMatchers(new AntPathRequestMatcher("/signup")).permitAll()
+                .requestMatchers(new AntPathRequestMatcher("/login")).permitAll()
+                .requestMatchers(new AntPathRequestMatcher("/")).permitAll()
+                .anyRequest().authenticated()
+                .and()
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
-                //api 경로
-                .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers(new AntPathRequestMatcher("/signup")).permitAll()
-                        .requestMatchers(new AntPathRequestMatcher("/login")).permitAll()
-                        .requestMatchers(new AntPathRequestMatcher("/")).permitAll()
-//                        .requestMatchers("/admin/**").hasRole("ADMIN")
-                        .anyRequest().authenticated()) // 나머지 경로는 jwt 인증 해야함
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class) // JWT를 통해 인증된 사용자를 식별하는 필터
-                .build();
+        return http.build();
     }
 
     // CORS 설정

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/SecurityConfig.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/SecurityConfig.java
@@ -41,6 +41,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(new AntPathRequestMatcher("/signup")).permitAll()
                         .requestMatchers(new AntPathRequestMatcher("/login")).permitAll()
+                        .requestMatchers(new AntPathRequestMatcher("/")).permitAll()
+//                        .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()) // 나머지 경로는 jwt 인증 해야함
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class) // JWT를 통해 인증된 사용자를 식별하는 필터
                 .build();

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/SecurityConfig.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/SecurityConfig.java
@@ -5,42 +5,51 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-import static org.springframework.security.config.Customizer.withDefaults;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    private static final String[] AUTH_WHITE_LIST = {"/api/auth/**"};
 
-//    @Bean   // Spring Security 기능(인증, 인가) 비활성화
-//    public WebSecurityCustomizer configure() {
-//        return (web) -> web.ignoring()
-//                .requestMatchers(toH2Console())
-//                .requestMatchers("/static/**");
-//    }
+    private final CustomJwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean   // 특정 HTTP 요청에 대한 웹 기반 보안 구성. (인증인가, 로그인, 로그아웃 설정)
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-//        http
-//                .authorizeRequests(authorize -> authorize
-//                        .requestMatchers("/login", "/signup").permitAll()
-//                        .anyRequest().authenticated()
-//                )
-//                .formLogin(login -> login
-//                        .loginPage("/login").defaultSuccessUrl("/")
-//                )
-//                .logout(logout ->
-//                        logout.logoutSuccessUrl("/").invalidateHttpSession(true)
-//                )
-//                .csrf(AbstractHttpConfigurer::disable)
-//                .headers(headers -> headers.frameOptions(FrameOptionsConfig::sameOrigin));
-        http.authorizeHttpRequests((authz) -> authz.anyRequest().authenticated())
-                .httpBasic(withDefaults());
+        return http
+                .csrf(AbstractHttpConfigurer::disable)  // 실제 운영 환경에서는 활성화하는 걸 권장
+                .httpBasic(AbstractHttpConfigurer::disable) // HTTP 기본 인증 비활성화(사용자 이름과 비밀번호를 평문으로 전송하기 때문에 보안에 취약)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션을 사용하지 않기 때문에 STATELESS로 설정
+                .exceptionHandling(exception -> exception.authenticationEntryPoint(jwtAuthenticationEntryPoint)) // 인증되지 않은 사용자의 접근에 대해 401 Unauthorized 에러를 리턴하는 클래스
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers(new AntPathRequestMatcher("/api/auth/**")).permitAll()
+                        .anyRequest().authenticated()) // 인증이 필요한 경로 설정
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class) // JWT를 통해 인증된 사용자를 식별하는 필터
+                .build();
+    }
 
-        return http.build();
+    // CORS 설정
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                        .allowedOrigins("*")
+                        .allowedOriginPatterns("*")
+                        .allowedMethods("*");
+            }
+        };
     }
 
 }

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/SecurityConfig.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/SecurityConfig.java
@@ -21,7 +21,6 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    private static final String[] AUTH_WHITE_LIST = {"/api/auth/**"};
 
     private final CustomJwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
@@ -31,8 +30,13 @@ public class SecurityConfig {
         return http
                 .csrf(AbstractHttpConfigurer::disable)  // 실제 운영 환경에서는 활성화하는 걸 권장
                 .httpBasic(AbstractHttpConfigurer::disable) // HTTP 기본 인증 비활성화(사용자 이름과 비밀번호를 평문으로 전송하기 때문에 보안에 취약)
-//                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션을 사용하지 않기 때문에 STATELESS로 설정
-                .exceptionHandling(exception -> exception.authenticationEntryPoint(jwtAuthenticationEntryPoint)) // 인증되지 않은 사용자의 접근에 대해 401 Unauthorized 에러를 리턴하는 클래스
+
+                // 세션을 사용하지 않기 때문에 STATELESS로 설정
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+                // 인증되지 않은 사용자의 접근에 대해 401 Unauthorized 에러를 리턴하는 클래스
+                .exceptionHandling(exception -> exception.authenticationEntryPoint(jwtAuthenticationEntryPoint))
+
                 //api 경로
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(new AntPathRequestMatcher("/signup")).permitAll()

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/TimezoneConfig.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/TimezoneConfig.java
@@ -1,0 +1,16 @@
+package com.tobehome.tobehomeserver.config;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.TimeZone;
+
+@Configuration
+public class TimezoneConfig {
+    private static final String KST = "Asia/Seoul";
+
+    @PostConstruct
+    public void init() {
+        TimeZone.setDefault(TimeZone.getTimeZone(KST));
+    }
+}

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/jwt/CustomJwtAuthenticationEntryPoint.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/jwt/CustomJwtAuthenticationEntryPoint.java
@@ -1,0 +1,30 @@
+package com.tobehome.tobehomeserver.config.jwt;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomJwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    /*
+        인증되지 않은(로그인하지 않은) 사용자의 접근에 대해 401 Unauthorized 에러를 리턴하는 클래스
+     */
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException, ServletException {
+        // 사용자가 인증되지 않은 경우에 호출되는 메서드
+        setResponse(response);
+    }
+
+    private void setResponse(HttpServletResponse response) {
+        // 401 Unauthorized 에러를 리턴
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+}

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/jwt/JwtAuthenticationFilter.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/jwt/JwtAuthenticationFilter.java
@@ -26,12 +26,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
+        System.out.println("doFilterInternal 실행됨");
         try {
             final String token = getTokenFromJwt(request);  // HTTP 요청에서 JWT 토큰 추출
+            System.out.println("token: " + token);
 
             // JWT 토큰 유효성 검사
             if (jwtTokenProvider.validateToken(token) == JwtValidationType.VALID_JWT) {
                 Long memberId = jwtTokenProvider.getUserFromJwt(token);
+                System.out.println("memberId: " + memberId);
 
                 // 사용자 인증 객체 생성
                 UserAuthentication authentication = new UserAuthentication(memberId.toString(), null, null);
@@ -41,10 +44,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
                 // SecurityContextHolder에 인증 객체 설정
                 SecurityContextHolder.getContext().setAuthentication(authentication);
+                System.out.println("Security Context에 인증 정보를 저장했습니다");
             }
         } catch(Exception exception){
+            System.out.println("exception: " + exception);
 //            throw new BusinessException("Invalid Token");
         }
+
+        // 다음 필터로 넘어감
+        filterChain.doFilter(request, response);
     }
 
     private String getTokenFromJwt(HttpServletRequest request) {

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/jwt/JwtAuthenticationFilter.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/jwt/JwtAuthenticationFilter.java
@@ -33,7 +33,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             // JWT 토큰 유효성 검사
             if (jwtTokenProvider.validateToken(token) == JwtValidationType.VALID_JWT) {
                 Long memberId = jwtTokenProvider.getUserFromJwt(token);
-                System.out.println("memberId: " + memberId);
 
                 // 사용자 인증 객체 생성
                 UserAuthentication authentication = new UserAuthentication(memberId.toString(), null, null);

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/jwt/JwtAuthenticationFilter.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/jwt/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.tobehome.tobehomeserver.config.jwt;
 
+import com.tobehome.tobehomeserver.exception.InvalidTokenException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -26,10 +27,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
-        System.out.println("doFilterInternal 실행됨");
         try {
             final String token = getTokenFromJwt(request);  // HTTP 요청에서 JWT 토큰 추출
-            System.out.println("token: " + token);
 
             // JWT 토큰 유효성 검사
             if (jwtTokenProvider.validateToken(token) == JwtValidationType.VALID_JWT) {
@@ -44,14 +43,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
                 // SecurityContextHolder에 인증 객체 설정
                 SecurityContextHolder.getContext().setAuthentication(authentication);
-                System.out.println("Security Context에 인증 정보를 저장했습니다");
             }
         } catch(Exception exception){
-            System.out.println("exception: " + exception);
-//            throw new BusinessException("Invalid Token");
+            throw new InvalidTokenException("유효한 JWT 토큰이 없습니다");
         }
 
-        // 다음 필터로 넘어감
         filterChain.doFilter(request, response);
     }
 

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/jwt/JwtAuthenticationFilter.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,58 @@
+package com.tobehome.tobehomeserver.config.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    /*
+        JWT를 통해 인증된 사용자를 식별하는 필터.
+        JWT를 통해 인증된 사용자가 요청을 보낼 때마다 JWT의 유효성을 검사하고, 유효한 JWT인 경우 SecurityContextHolder에 사용자 정보를 저장함.
+     */
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        try {
+            final String token = getTokenFromJwt(request);  // HTTP 요청에서 JWT 토큰 추출
+
+            // JWT 토큰 유효성 검사
+            if (jwtTokenProvider.validateToken(token) == JwtValidationType.VALID_JWT) {
+                Long memberId = jwtTokenProvider.getUserFromJwt(token);
+
+                // 사용자 인증 객체 생성
+                UserAuthentication authentication = new UserAuthentication(memberId.toString(), null, null);
+
+                // request 정보로 사용자 객체 디테일 설정
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+                // SecurityContextHolder에 인증 객체 설정
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        } catch(Exception exception){
+//            throw new BusinessException("Invalid Token");
+        }
+    }
+
+    private String getTokenFromJwt(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring("Bearer ".length());
+        }
+
+        return null;
+    }
+}

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/jwt/JwtTokenProvider.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/jwt/JwtTokenProvider.java
@@ -25,9 +25,6 @@ public class JwtTokenProvider {
 
     @PostConstruct
     protected void init() {
-        // JWT_SECRET 값을 Base64로 인코딩하는 메서드.
-        // base64 라이브러리에서 제공하는 인코더를 사용하여 JWT_SECRET 값을 인코딩
-        // encodeToString을 사용하여 byte[]를 String으로 변환
         JWT_SECRET = Base64.getEncoder().encodeToString(JWT_SECRET.getBytes(StandardCharsets.UTF_8));
     }
 

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/jwt/JwtTokenProvider.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/jwt/JwtTokenProvider.java
@@ -1,5 +1,6 @@
 package com.tobehome.tobehomeserver.config.jwt;
 
+import com.tobehome.tobehomeserver.domain.entity.Member;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
@@ -35,7 +36,11 @@ public class JwtTokenProvider {
         final Claims claims = Jwts.claims()
                 .setIssuedAt(now)       // 발급 시간을 지금으로 설정
                 .setExpiration(new Date(now.getTime() + expiredTokenTime));     // 만료 시간 설정
-        claims.put("id", authentication.getPrincipal());        // 사용자의 id를 Claim에 저장
+
+        // 사용자의 id를 Claim에 저장
+        Member memberEntity = (Member) authentication.getPrincipal();
+        Long id = memberEntity.getId();
+        claims.put("id", id);
 
         // JWT는 Header, Claim(payload), Signature 세 부분으로 구성되어 있음.
         return Jwts.builder()

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/jwt/JwtTokenProvider.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/jwt/JwtTokenProvider.java
@@ -31,20 +31,18 @@ public class JwtTokenProvider {
         JWT_SECRET = Base64.getEncoder().encodeToString(JWT_SECRET.getBytes(StandardCharsets.UTF_8));
     }
 
-    public String generateToken(Authentication authentication, Long expiredTokenTime) {
-        final Date now = new Date();
+    public String generateToken(Authentication authentication) {
+
 
         // Claim: JWT 토큰에 저장되는 정보
         final Claims claims = Jwts.claims()
-                .setIssuedAt(now)       // 발급 시간을 지금으로 설정
-                .setExpiration(new Date(now.getTime() + expiredTokenTime));     // 만료 시간 설정
+                .setIssuedAt(new Date());
 
         // 사용자의 id를 Claim에 저장
         Member memberEntity = (Member) authentication.getPrincipal();
         Long id = memberEntity.getId();
         claims.put("id", id);
 
-        // JWT는 Header, Claim(payload), Signature 세 부분으로 구성되어 있음.
         return Jwts.builder()
                 .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
                 .setClaims(claims)

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/jwt/JwtTokenProvider.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/jwt/JwtTokenProvider.java
@@ -1,0 +1,84 @@
+package com.tobehome.tobehomeserver.config.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+    /*
+        JWT 토큰을 생성하고 검증하는 클래스
+     */
+
+    @Value("${jwt.secret}")
+    private String JWT_SECRET;
+
+    @PostConstruct
+    protected void init() {
+        // JWT_SECRET 값을 Base64로 인코딩하는 메서드.
+        // base64 라이브러리에서 제공하는 인코더를 사용하여 JWT_SECRET 값을 인코딩
+        // encodeToString을 사용하여 byte[]를 String으로 변환
+        JWT_SECRET = Base64.getEncoder().encodeToString(JWT_SECRET.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String generateToken(Authentication authentication, Long expiredTokenTime) {
+        final Date now = new Date();
+
+        // Claim: JWT 토큰에 저장되는 정보
+        final Claims claims = Jwts.claims()
+                .setIssuedAt(now)       // 발급 시간을 지금으로 설정
+                .setExpiration(new Date(now.getTime() + expiredTokenTime));     // 만료 시간 설정
+        claims.put("id", authentication.getPrincipal());        // 사용자의 id를 Claim에 저장
+
+        // JWT는 Header, Claim(payload), Signature 세 부분으로 구성되어 있음.
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .setClaims(claims)
+                .signWith(getSigningKey())
+                .compact();
+    }
+
+    private SecretKey getSigningKey() { // 서명 키를 생성하는 메서드.
+        String encodedKey= Base64.getEncoder().encodeToString(JWT_SECRET.getBytes());
+        return Keys.hmacShaKeyFor(encodedKey.getBytes());   // HMAC SHA 알고리즘으로 SecretKey를 생성
+    }
+
+    public JwtValidationType validateToken(String token) {
+        // 토큰의 유효성 + 만료일자 확인
+        try {
+            final Claims claims = getBody(token);
+            return JwtValidationType.VALID_JWT;
+        } catch (MalformedJwtException ex) {
+            return JwtValidationType.INVALID_JWT_TOKEN;
+        } catch (ExpiredJwtException ex) {
+            return JwtValidationType.EXPIRED_JWT_TOKEN;
+        } catch (UnsupportedJwtException ex) {
+            return JwtValidationType.UNSUPPORTED_JWT_TOKEN;
+        } catch (IllegalArgumentException ex) {
+            return JwtValidationType.EMPTY_JWT;
+        }
+    }
+
+    private Claims getBody(final String token) {    // 토큰에서 Body 추출
+        return Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    public Long getUserFromJwt(String token) {
+        Claims claims = getBody(token);
+        return Long.valueOf(claims.get("id").toString());
+    }
+}

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/jwt/JwtTokenProvider.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/jwt/JwtTokenProvider.java
@@ -6,6 +6,7 @@ import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
@@ -16,6 +17,7 @@ import java.util.Date;
 
 @Component
 @RequiredArgsConstructor
+@PropertySource("classpath:application-secret.properties")
 public class JwtTokenProvider {
     /*
         JWT 토큰을 생성하고 검증하는 클래스

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/jwt/JwtValidationType.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/jwt/JwtValidationType.java
@@ -1,0 +1,10 @@
+package com.tobehome.tobehomeserver.config.jwt;
+
+public enum JwtValidationType {
+    VALID_JWT,
+    INVALID_JWT_SIGNATURE,
+    INVALID_JWT_TOKEN,
+    EXPIRED_JWT_TOKEN,
+    UNSUPPORTED_JWT_TOKEN,
+    EMPTY_JWT
+}

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/jwt/UserAuthentication.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/jwt/UserAuthentication.java
@@ -1,0 +1,21 @@
+package com.tobehome.tobehomeserver.config.jwt;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+public class UserAuthentication extends UsernamePasswordAuthenticationToken {
+    /*
+        JWT를 통해 인증된 사용자를 나타내는 클래스.
+        사용자가 성공적으로 인정되었을 때, SecurityContextHolder에 저장되어 Spring Security가 현재 사용자를 식별할 수 있도록 함.
+     */
+
+    // 생성자
+    public UserAuthentication(Object principal, Object credentials, Collection<? extends GrantedAuthority> authorities) {
+        // principal: 사용자의 식별자(사용자 ID 등)
+        // credentials: 사용자의 비밀번호. JWT에서는 주로 null이 될 수 있음.
+        // authorities: 사용자의 권한 목록
+        super(principal, credentials, authorities);
+    }
+}

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/controller/MemberController.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/controller/MemberController.java
@@ -25,7 +25,6 @@ public class MemberController {
         로그인/회원가입 관련 API
      */
     @PostMapping("signup")
-    @PreAuthorize("permitAll()")
     public ResponseEntity<Map<String, Object>> signup(@RequestBody MemberSignInRequest request) {
         Long id = memberService.signup(request);
         Map<String, Object> response = new HashMap<>();

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/controller/MemberController.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/controller/MemberController.java
@@ -6,27 +6,39 @@ import com.tobehome.tobehomeserver.service.MemberService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.HashMap;
+import java.util.Map;
+
+@RequestMapping(value = "/")
 @RestController
 @RequiredArgsConstructor
 public class MemberController {
     private final MemberService memberService;
 
-    @PostMapping("/signup")
-    public Long signup(@RequestBody MemberSignInRequest request) {
-        System.out.println("signup 실행됨");
-        return memberService.signup(request);
+    /*
+        로그인/회원가입 관련 API
+     */
+    @PostMapping("signup")
+    @PreAuthorize("permitAll()")
+    public ResponseEntity<Map<String, Object>> signup(@RequestBody MemberSignInRequest request) {
+        Long id = memberService.signup(request);
+        Map<String, Object> response = new HashMap<>();
+        response.put("id", id);
+        return ResponseEntity.created(null).body(response);
     }
 
-    @PostMapping("/login")
+    @PostMapping("login")
     public MemberLogInResponse login(@RequestBody MemberSignInRequest request) {
         return memberService.login(request);
     }
 
-    @GetMapping("/logout")
+    @GetMapping("logout")
     public String logout(HttpServletRequest request, HttpServletResponse response) {
         new SecurityContextLogoutHandler().logout(request, response,
                 SecurityContextHolder.getContext().getAuthentication());

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/controller/MemberController.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/controller/MemberController.java
@@ -1,0 +1,33 @@
+package com.tobehome.tobehomeserver.controller;
+
+import com.tobehome.tobehomeserver.domain.entity.Member;
+import com.tobehome.tobehomeserver.dto.request.member.MemberRequestDto;
+import com.tobehome.tobehomeserver.service.MemberService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@Lazy
+public class MemberController {
+    private final MemberService memberService;
+
+    @PostMapping("/signup")
+    public String signup(MemberRequestDto request) {
+        memberService.save(request);
+        return "redirect:/login";
+    }
+
+    @GetMapping("/logout")
+    public String logout(HttpServletRequest request, HttpServletResponse response) {
+        new SecurityContextLogoutHandler().logout(request, response,
+                SecurityContextHolder.getContext().getAuthentication());
+        return "redirect:/";
+    }
+
+}

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/controller/MemberController.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.tobehome.tobehomeserver.controller;
 
+import com.tobehome.tobehomeserver.dto.request.member.MemberLogInRequest;
 import com.tobehome.tobehomeserver.dto.request.member.MemberSignInRequest;
 import com.tobehome.tobehomeserver.dto.response.member.MemberLogInResponse;
 import com.tobehome.tobehomeserver.service.MemberService;
@@ -33,10 +34,14 @@ public class MemberController {
     }
 
     @PostMapping("login")
-    public ResponseEntity<Map<String, Object>> login(@RequestBody MemberSignInRequest request) {
-        String token = memberService.login(request);
-        Map<String, Object> response = new HashMap<>();
-        response.put("token", token);
+//    public ResponseEntity<Map<String, Object>> login(@RequestBody MemberSignInRequest request) {
+//        String token = memberService.login(request);
+//        Map<String, Object> response = new HashMap<>();
+//        response.put("token", token);
+//        return ResponseEntity.ok(response);
+//    }
+    public ResponseEntity<Map<String, Object>> login(@RequestBody MemberLogInRequest request) {
+        Map<String, Object> response = memberService.login(request);
         return ResponseEntity.ok(response);
     }
 

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/controller/MemberController.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.tobehome.tobehomeserver.controller;
 
 import com.tobehome.tobehomeserver.dto.request.member.MemberSignInRequest;
+import com.tobehome.tobehomeserver.dto.response.member.MemberLogInResponse;
 import com.tobehome.tobehomeserver.service.MemberService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -16,7 +17,13 @@ public class MemberController {
 
     @PostMapping("/signup")
     public Long signup(@RequestBody MemberSignInRequest request) {
+        System.out.println("signup 실행됨");
         return memberService.signup(request);
+    }
+
+    @PostMapping("/login")
+    public MemberLogInResponse login(@RequestBody MemberSignInRequest request) {
+        return memberService.login(request);
     }
 
     @GetMapping("/logout")

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/controller/MemberController.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/controller/MemberController.java
@@ -1,25 +1,22 @@
 package com.tobehome.tobehomeserver.controller;
 
-import com.tobehome.tobehomeserver.domain.entity.Member;
-import com.tobehome.tobehomeserver.dto.request.member.MemberRequestDto;
+import com.tobehome.tobehomeserver.dto.request.member.MemberSignInRequest;
 import com.tobehome.tobehomeserver.service.MemberService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Lazy;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@Lazy
 public class MemberController {
     private final MemberService memberService;
 
     @PostMapping("/signup")
-    public String signup(MemberRequestDto request) {
-        memberService.save(request);
+    public String signup(MemberSignInRequest request) {
+        memberService.signup(request);
         return "redirect:/login";
     }
 

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/controller/MemberController.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/controller/MemberController.java
@@ -34,15 +34,18 @@ public class MemberController {
     }
 
     @PostMapping("login")
-    public MemberLogInResponse login(@RequestBody MemberSignInRequest request) {
-        return memberService.login(request);
+    public ResponseEntity<Map<String, Object>> login(@RequestBody MemberSignInRequest request) {
+        String token = memberService.login(request);
+        Map<String, Object> response = new HashMap<>();
+        response.put("token", token);
+        return ResponseEntity.ok(response);
     }
 
-    @GetMapping("logout")
-    public String logout(HttpServletRequest request, HttpServletResponse response) {
-        new SecurityContextLogoutHandler().logout(request, response,
-                SecurityContextHolder.getContext().getAuthentication());
-        return "redirect:/";
-    }
+//    @GetMapping("logout")
+//    public String logout(HttpServletRequest request, HttpServletResponse response) {
+//        new SecurityContextLogoutHandler().logout(request, response,
+//                SecurityContextHolder.getContext().getAuthentication());
+//        return "redirect:/";
+//    }
 
 }

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/controller/MemberController.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/controller/MemberController.java
@@ -15,9 +15,8 @@ public class MemberController {
     private final MemberService memberService;
 
     @PostMapping("/signup")
-    public String signup(MemberSignInRequest request) {
-        memberService.signup(request);
-        return "redirect:/login";
+    public Long signup(@RequestBody MemberSignInRequest request) {
+        return memberService.signup(request);
     }
 
     @GetMapping("/logout")

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/domain/entity/Member.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/domain/entity/Member.java
@@ -1,5 +1,6 @@
 package com.tobehome.tobehomeserver.domain.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.security.core.GrantedAuthority;
@@ -26,6 +27,7 @@ public class Member implements UserDetails {
     private String nickname;
 
     @Column(nullable = false)
+    @JsonIgnore
     private String password;
 
     @Builder

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/domain/entity/Member.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/domain/entity/Member.java
@@ -1,0 +1,72 @@
+package com.tobehome.tobehomeserver.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Setter
+public class Member implements UserDetails {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(updatable = false, nullable = false)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false, unique = true)
+    private String nickname;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Builder
+    public Member(String email, String nickname, String password) {
+        this.email = email;
+        this.nickname = nickname;
+        this.password = password;
+    }
+
+
+    /*
+        UserDetails 인터페이스의 메서드 구현
+        - UserDetails: 스프링 시큐리티에서 사용자의 정보를 담는 인터페이스
+     */
+    @Override   // 권한 반환
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("member"));
+    }
+
+    @Override   // 사용자의 id 반환(고유한 값)
+    public String getUsername() {
+        return nickname;
+    }
+
+    @Override   // 계정 만료 여부 반환
+    public boolean isAccountNonExpired() {
+        return true;    // true: 만료되지 않음
+    }
+
+    @Override   // 계정 잠김 여부 반환
+    public boolean isAccountNonLocked() {
+        return true;    // true: 잠기지 않음
+    }
+
+    @Override   // 패스워드 만료 여부 반환
+    public boolean isCredentialsNonExpired() {
+        return true;   //
+    }
+
+    @Override   // 계정 활성화 여부 반환
+    public boolean isEnabled() {
+        return true;    // true: 활성화
+    }
+}

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/domain/entity/Member.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/domain/entity/Member.java
@@ -19,7 +19,7 @@ public class Member implements UserDetails {
     @Column(updatable = false, nullable = false)
     private Long id;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private String email;
 
     @Column(nullable = false, unique = true)

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/dto/ErrorResponse.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/dto/ErrorResponse.java
@@ -1,0 +1,11 @@
+package com.tobehome.tobehomeserver.dto;
+
+import lombok.*;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter @Setter
+public class ErrorResponse {
+    private String message;
+}

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/dto/request/member/MemberLogInRequest.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/dto/request/member/MemberLogInRequest.java
@@ -1,11 +1,12 @@
 package com.tobehome.tobehomeserver.dto.request.member;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter @Setter
-public class MemberRequestDto {
-    private String email;
+@NoArgsConstructor
+public class MemberLogInRequest {
     private String nickname;
     private String password;
 }

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/dto/request/member/MemberLogInRequest.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/dto/request/member/MemberLogInRequest.java
@@ -1,12 +1,34 @@
 package com.tobehome.tobehomeserver.dto.request.member;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import com.tobehome.tobehomeserver.domain.entity.Member;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
 
-@Getter @Setter
+//@Getter @Setter
+//@NoArgsConstructor
+//public class MemberLogInRequest {
+//    private String nickname;
+//    private String password;
+//}
+
+@Data
+@AllArgsConstructor
 @NoArgsConstructor
+@Getter
+@Setter
 public class MemberLogInRequest {
+
+    @NotBlank(message = "닉네임을 입력해주세요.")
     private String nickname;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
     private String password;
+
+    public Member toEntity(String encodedPassword) {
+        return Member.builder()
+                .nickname(this.nickname)
+                .password(encodedPassword)
+                .build();
+    }
+
 }

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/dto/request/member/MemberRequestDto.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/dto/request/member/MemberRequestDto.java
@@ -1,0 +1,11 @@
+package com.tobehome.tobehomeserver.dto.request.member;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class MemberRequestDto {
+    private String email;
+    private String nickname;
+    private String password;
+}

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/dto/request/member/MemberSignInRequest.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/dto/request/member/MemberSignInRequest.java
@@ -1,0 +1,29 @@
+package com.tobehome.tobehomeserver.dto.request.member;
+
+import com.tobehome.tobehomeserver.domain.entity.Member;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter @Setter
+@NoArgsConstructor
+public class MemberSignInRequest {
+
+    @NotBlank(message = "이메일을 입력해주세요.")
+    private String email;
+
+    @NotBlank(message = "닉네임을 입력해주세요.")
+    private String nickname;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
+
+    public Member toEntity(String encodedPassword) {
+        return Member.builder()
+                .email(this.email)
+                .nickname(this.nickname)
+                .password(encodedPassword)
+                .build();
+    }
+}

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/dto/request/member/MemberSignInRequest.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/dto/request/member/MemberSignInRequest.java
@@ -2,11 +2,11 @@ package com.tobehome.tobehomeserver.dto.request.member;
 
 import com.tobehome.tobehomeserver.domain.entity.Member;
 import jakarta.validation.constraints.NotBlank;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Getter @Setter
+@Data
+@AllArgsConstructor
 @NoArgsConstructor
 public class MemberSignInRequest {
 

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/dto/response/member/MemberLogInResponse.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/dto/response/member/MemberLogInResponse.java
@@ -1,0 +1,13 @@
+package com.tobehome.tobehomeserver.dto.response.member;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class MemberLogInResponse {
+    private String accessToken;
+
+    public MemberLogInResponse(String accessToken) {
+        this.accessToken = accessToken;
+    }
+}

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/dto/response/member/MemberLogInResponse.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/dto/response/member/MemberLogInResponse.java
@@ -1,13 +1,12 @@
 package com.tobehome.tobehomeserver.dto.response.member;
 
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 @Getter @Setter
 public class MemberLogInResponse {
     private String accessToken;
 
-    public MemberLogInResponse(String accessToken) {
-        this.accessToken = accessToken;
-    }
 }

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/exception/GlobalExceptionHandler.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/exception/GlobalExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.tobehome.tobehomeserver.exception;
+
+import com.tobehome.tobehomeserver.dto.ErrorResponse;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<Object> handleDataIntegrityViolation(DataIntegrityViolationException ex) {
+        String message = "이미 존재하는 닉네임입니다.";
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(message));
+    }
+
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<Object> handleAuthenticationException(AuthenticationException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(ex.getMessage()));
+    }
+}

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/exception/InvalidTokenException.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/exception/InvalidTokenException.java
@@ -1,0 +1,7 @@
+package com.tobehome.tobehomeserver.exception;
+
+public class InvalidTokenException extends RuntimeException {
+    public InvalidTokenException(String message) {
+        super(message);
+    }
+}

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/repository/MemberJpaRepository.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/repository/MemberJpaRepository.java
@@ -10,6 +10,8 @@ public interface MemberJpaRepository extends JpaRepository<Member, Long> {
     boolean existsByNickname(String nickname);
     Optional<Member> findByEmail(String email);
 
+    boolean existsByEmail(String email);
+
     Optional<Member> findByNickname(String nickname);
 
 }

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/repository/MemberJpaRepository.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/repository/MemberJpaRepository.java
@@ -1,0 +1,11 @@
+package com.tobehome.tobehomeserver.repository;
+
+import com.tobehome.tobehomeserver.domain.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface MemberJpaRepository extends JpaRepository<Member, Long> {
+    Member findByEmail(String email);
+
+    Member findByNickname(String nickname);
+}

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/repository/MemberJpaRepository.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/repository/MemberJpaRepository.java
@@ -11,4 +11,5 @@ public interface MemberJpaRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
 
     Optional<Member> findByNickname(String nickname);
+
 }

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/repository/MemberJpaRepository.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/repository/MemberJpaRepository.java
@@ -3,9 +3,12 @@ package com.tobehome.tobehomeserver.repository;
 import com.tobehome.tobehomeserver.domain.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 
 public interface MemberJpaRepository extends JpaRepository<Member, Long> {
-    Member findByEmail(String email);
+    boolean existsByNickname(String nickname);
+    Optional<Member> findByEmail(String email);
 
-    Member findByNickname(String nickname);
+    Optional<Member> findByNickname(String nickname);
 }

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/service/MemberService.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/service/MemberService.java
@@ -49,11 +49,9 @@ public class MemberService implements UserDetailsService {
      */
     public MemberLogInResponse login(MemberSignInRequest dto) {
         Optional<Member> optionalMember = memberJpaRepository.findByNickname(dto.getNickname());
-        System.out.println("optionalMember: " + optionalMember);
 
         // nickname이 일치하는 Member가 없는 경우
         if (optionalMember.isEmpty()) {
-            System.out.println("optionalMember.isEmpty()");
             return null;
         }
 
@@ -62,11 +60,9 @@ public class MemberService implements UserDetailsService {
 
         // password가 일치하지 않으면 null 반환
         if(!passwordEncoder.matches(dto.getPassword(), member.getPassword())) {
-            System.out.println("!passwordEncoder.matches(dto.getPassword(), member.getPassword())");
             return null;
         }
 
-        System.out.println("password 일치");
 
         UsernamePasswordAuthenticationToken authenticationToken =
                 new UsernamePasswordAuthenticationToken(dto.getNickname(), dto.getPassword());
@@ -77,12 +73,9 @@ public class MemberService implements UserDetailsService {
         // 이 과정에서 CustomUserDetailsService 에서 우리가 재정의한 loadUserByUsername 메서드 호출
         Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
 
-        System.out.println("authentication: " + authentication);
-
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
         String accessToken = jwtTokenProvider.generateToken(authentication, 60*60*1000L);
-        System.out.println("최종 accessToken: " + accessToken);
         return new MemberLogInResponse(accessToken);
     }
 

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/service/MemberService.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/service/MemberService.java
@@ -1,0 +1,43 @@
+package com.tobehome.tobehomeserver.service;
+
+import com.tobehome.tobehomeserver.domain.entity.Member;
+import com.tobehome.tobehomeserver.dto.request.member.MemberRequestDto;
+import com.tobehome.tobehomeserver.repository.MemberJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+
+@Service
+@RequiredArgsConstructor
+@Lazy
+public class MemberService implements UserDetailsService {
+    private final MemberJpaRepository memberJpaRepository;
+    private final BCryptPasswordEncoder passwordEncoder;
+
+//    public Member signup(MemberRequestDto memberRequestDto) {
+//        String encodedPassword = passwordEncoder.encode(memberRequestDto.getPassword());
+//        Member member = new Member(memberRequestDto.getEmail(), memberRequestDto.getNickname(), memberRequestDto.getPassword());
+//        return memberJpaRepository.save(member);
+//    }
+
+    public Long save(MemberRequestDto dto) {
+        return memberJpaRepository.save(Member.builder()
+                .email(dto.getEmail())
+                .nickname(dto.getNickname())
+                .password(passwordEncoder.encode(dto.getPassword()))    // 패스워드는 암호화하여 저장
+                .build()).getId();
+    }
+    @Override
+    public UserDetails loadUserByUsername(String nickname) throws UsernameNotFoundException {
+        return memberJpaRepository.findByNickname(nickname);
+    }
+
+}

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/service/MemberService.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/service/MemberService.java
@@ -1,10 +1,16 @@
 package com.tobehome.tobehomeserver.service;
 
+import com.tobehome.tobehomeserver.config.jwt.JwtTokenProvider;
 import com.tobehome.tobehomeserver.domain.entity.Member;
 import com.tobehome.tobehomeserver.dto.request.member.MemberLogInRequest;
 import com.tobehome.tobehomeserver.dto.request.member.MemberSignInRequest;
+import com.tobehome.tobehomeserver.dto.response.member.MemberLogInResponse;
 import com.tobehome.tobehomeserver.repository.MemberJpaRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -20,6 +26,8 @@ import java.util.Optional;
 public class MemberService implements UserDetailsService {
     private final MemberJpaRepository memberJpaRepository;
     private final BCryptPasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
 
     /**
      * 닉네임 중복 체크(중복되면 true)
@@ -33,29 +41,49 @@ public class MemberService implements UserDetailsService {
      */
     public Long signup(MemberSignInRequest dto) {
         Member member = dto.toEntity(passwordEncoder.encode(dto.getPassword()));
-        System.out.println(member.getNickname());
         return memberJpaRepository.save(member).getId();
     }
 
     /**
      * 로그인
      */
-    public Member login(MemberSignInRequest dto) {
+    public MemberLogInResponse login(MemberSignInRequest dto) {
         Optional<Member> optionalMember = memberJpaRepository.findByNickname(dto.getNickname());
+        System.out.println("optionalMember: " + optionalMember);
 
-        // nickname이 일치하는 Member가 없으면 null 반환
+        // nickname이 일치하는 Member가 없는 경우
         if (optionalMember.isEmpty()) {
+            System.out.println("optionalMember.isEmpty()");
             return null;
         }
 
         Member member = optionalMember.get();
+        System.out.println("password: " + member.getPassword());
 
         // password가 일치하지 않으면 null 반환
-        if (!member.getPassword().equals(dto.getPassword())) {
+        if(!passwordEncoder.matches(dto.getPassword(), member.getPassword())) {
+            System.out.println("!passwordEncoder.matches(dto.getPassword(), member.getPassword())");
             return null;
         }
 
-        return member;
+        System.out.println("password 일치");
+
+        UsernamePasswordAuthenticationToken authenticationToken =
+                new UsernamePasswordAuthenticationToken(dto.getNickname(), dto.getPassword());
+
+        System.out.println("authenticationToken: " + authenticationToken);
+
+        // authenticationToken 객체를 통해 Authentication 객체 생성
+        // 이 과정에서 CustomUserDetailsService 에서 우리가 재정의한 loadUserByUsername 메서드 호출
+        Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+
+        System.out.println("authentication: " + authentication);
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        String accessToken = jwtTokenProvider.generateToken(authentication, 60*60*1000L);
+        System.out.println("최종 accessToken: " + accessToken);
+        return new MemberLogInResponse(accessToken);
     }
 
     /**
@@ -70,10 +98,12 @@ public class MemberService implements UserDetailsService {
      * 닉네임으로 회원 조회
      */
     @Override
+    @Transactional
     public UserDetails loadUserByUsername(String nickname) throws UsernameNotFoundException {
         Member member = memberJpaRepository.findByNickname(nickname)
                 .orElseThrow(() -> new UsernameNotFoundException("해당 유저를 찾을 수 없습니다."));
 
+        System.out.println("loadUserByUsername 유저 찾음: " + member);
         return member;
     }
 

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/service/MemberService.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/service/MemberService.java
@@ -32,7 +32,9 @@ public class MemberService implements UserDetailsService {
      * 회원가입
      */
     public Long signup(MemberSignInRequest dto) {
-        return memberJpaRepository.save(dto.toEntity(passwordEncoder.encode(dto.getPassword()))).getId();
+        Member member = dto.toEntity(passwordEncoder.encode(dto.getPassword()));
+        System.out.println(member.getNickname());
+        return memberJpaRepository.save(member).getId();
     }
 
     /**

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/service/MemberService.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/service/MemberService.java
@@ -18,6 +18,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.dao.DataIntegrityViolationException;
 
 import java.util.Optional;
 
@@ -41,6 +42,7 @@ public class MemberService implements UserDetailsService {
      * 회원가입
      */
     public Long signup(MemberSignInRequest dto) {
+
         Member member = dto.toEntity(passwordEncoder.encode(dto.getPassword()));
         return memberJpaRepository.save(member).getId();
     }

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/service/MemberService.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/service/MemberService.java
@@ -75,7 +75,7 @@ public class MemberService implements UserDetailsService {
 
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
-        return jwtTokenProvider.generateToken(authentication, 60*60*1000L);
+        return jwtTokenProvider.generateToken(authentication, 60*60*1000L); // 토큰 유효시간: 1시간
     }
 
     /**

--- a/tobehomeserver/src/main/resources/application.yml
+++ b/tobehomeserver/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         #        show_sql: true //sout 통해 출력


### PR DESCRIPTION
## Description

- 회원가입, 로그인 기능 구현했습니다.
 - 회원가입할 때: 중복된 이름(닉네임)은 400 BAD REQUEST 반환
 - 회원가입할 때: 이메일은 중복 가능하도록 했습니다.
 - 패스워드는 DB에 암호화되어 저장됩니다(BCryptPasswordEncoder 사용)
- 토큰에는 member_id만 저장하고, 1시간 후 만료됩니다.
- ErrorResponse DTO 만들었습니다. 혹시 에러 메세지 보내야할 경우에 이 DTO 사용하시면 될 것 같습니다.
- 인증 인가: SecurityConfig에서 관리
 - 현재 /signup, /login, /에 대해서는 인증이 필요 없도록 열어두었습니다.
 
<img width="565" alt="image" src="https://github.com/GDSC-CAU/ToHome-BE/assets/102952855/1dcfaeab-0934-4744-9116-e4eae43443bc">

 - 인증인가에 관해서 수정하시려면 SecurityConfig 클래스에서 authorizeHttpRequests 부분 수정하시면 됩니다!


## Test

- 회원가입(정상적인 경우)
<img width="806" alt="image" src="https://github.com/GDSC-CAU/ToHome-BE/assets/102952855/56cc167c-2b64-48f8-97e3-10eb0791bff5">
<img width="676" alt="image" src="https://github.com/GDSC-CAU/ToHome-BE/assets/102952855/5bfcc753-159b-4607-bfb9-d5f9966b3a06">

비밀번호 암호화도 잘 된 것을 확인할 수 있습니다


- 회원가입(닉네임 중복)
<img width="786" alt="image" src="https://github.com/GDSC-CAU/ToHome-BE/assets/102952855/42d89c41-d28a-4bfd-9975-68bcdec53ff2">


- 로그인(정상적인 경우)
<img width="1008" alt="image" src="https://github.com/GDSC-CAU/ToHome-BE/assets/102952855/bc18d13d-b8aa-41cb-b450-e846243e76b2">


- 로그인(닉네임 또는 비밀번호 틀린 경우)
<img width="779" alt="image" src="https://github.com/GDSC-CAU/ToHome-BE/assets/102952855/1544ee40-11c1-4e71-be9b-b4949aacf9d8">
보안을 위해 "닉네임 또는 비밀번호가 일치하지 않습니다"로 통일했습니다.