### PR TITLE
[Feat] 게시글 연관관계

### DIFF
--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/PropertyConfig.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/config/PropertyConfig.java
@@ -4,6 +4,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 
 @Configuration
-//@PropertySource("classpath:application-secret.properties")
+@PropertySource("classpath:application-secret.properties")
 public class PropertyConfig {
 }

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/controller/PostRelationController.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/controller/PostRelationController.java
@@ -1,0 +1,44 @@
+package com.tobehome.tobehomeserver.controller;
+
+import com.tobehome.tobehomeserver.dto.request.PostRelationDTO;
+import com.tobehome.tobehomeserver.service.PostRelationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/posts/{interiorPostId}/related-posts")
+@RequiredArgsConstructor
+public class PostRelationController {
+
+    private final PostRelationService postRelationService;
+
+    @PostMapping("/{productPostId}")
+    public ResponseEntity<String> addPostRelation(@PathVariable Long interiorPostId, @PathVariable Long productPostId) {
+        try {
+            postRelationService.addPostRelation(interiorPostId, productPostId);
+            return ResponseEntity.ok("게시물 연관 관계가 추가되었습니다.");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("게시물 연관 관계 추가에 실패했습니다.");
+        }
+    }
+
+    @GetMapping
+    public ResponseEntity<List<PostRelationDTO>> getRelatedPosts(@PathVariable Long interiorPostId) {
+        List<PostRelationDTO> relatedPosts = postRelationService.getRelatedPosts(interiorPostId);
+        return ResponseEntity.ok(relatedPosts);
+    }
+
+    @DeleteMapping("/{productPostId}")
+    public ResponseEntity<String> removePostRelation(@PathVariable Long interiorPostId, @PathVariable Long productPostId) {
+        try {
+            postRelationService.removePostRelation(interiorPostId, productPostId);
+            return ResponseEntity.ok("게시물 연관 관계가 삭제되었습니다.");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("게시물 연관 관계 삭제에 실패했습니다.");
+        }
+    }
+}

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/domain/entity/PostRelation.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/domain/entity/PostRelation.java
@@ -1,0 +1,30 @@
+package com.tobehome.tobehomeserver.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Setter
+public class PostRelation {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(updatable = false, nullable = false)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "interior_post_id", nullable = false)
+    private Post interiorPost;
+
+    @ManyToOne
+    @JoinColumn(name = "product_post_id", nullable = false)
+    private Post productPost;
+
+    @Builder
+    public PostRelation(Post interiorPost, Post productPost) {
+        this.interiorPost = interiorPost;
+        this.productPost = productPost;
+    }
+}
+

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/dto/request/PostRelationDTO.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/dto/request/PostRelationDTO.java
@@ -1,0 +1,22 @@
+package com.tobehome.tobehomeserver.dto.request;
+
+import com.tobehome.tobehomeserver.domain.entity.PostRelation;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PostRelationDTO {
+    private Long id;
+    private Long interiorPostId;
+    private Long productPostId;
+
+    public static PostRelationDTO from(PostRelation postRelation) {
+        PostRelationDTO dto = new PostRelationDTO();
+        dto.setId(postRelation.getId());
+        dto.setInteriorPostId(postRelation.getInteriorPost().getId());
+        dto.setProductPostId(postRelation.getProductPost().getId());
+        return dto;
+    }
+}
+

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/repository/PostRelationJpaRepository.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/repository/PostRelationJpaRepository.java
@@ -1,0 +1,17 @@
+package com.tobehome.tobehomeserver.repository;
+
+import com.tobehome.tobehomeserver.domain.entity.PostRelation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface PostRelationJpaRepository extends JpaRepository<PostRelation, Long> {
+    List<PostRelation> findByInteriorPostId(Long interiorPostId);
+    List<PostRelation> findByProductPostId(Long productPostId);
+    Optional<PostRelation> findByInteriorPostIdAndProductPostId(Long interiorPostId, Long productPostId);
+    void deleteByInteriorPostIdAndProductPostId(Long interiorPostId, Long productPostId);
+}
+

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/service/MemberService.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/service/MemberService.java
@@ -43,6 +43,7 @@ public class MemberService implements UserDetailsService {
     /**
      * 회원가입
      */
+    @Transactional
     public Long signup(MemberSignInRequest dto) {
 
         Member member = dto.toEntity(passwordEncoder.encode(dto.getPassword()));
@@ -52,6 +53,7 @@ public class MemberService implements UserDetailsService {
     /**
      * 로그인
      */
+    @Transactional
     public Map<String, Object> login(MemberLogInRequest dto) {
 
         Optional<Member> optionalMember = memberJpaRepository.findByNickname(dto.getNickname());

--- a/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/service/PostRelationService.java
+++ b/tobehomeserver/src/main/java/com/tobehome/tobehomeserver/service/PostRelationService.java
@@ -1,0 +1,50 @@
+package com.tobehome.tobehomeserver.service;
+
+import com.tobehome.tobehomeserver.domain.entity.Post;
+import com.tobehome.tobehomeserver.domain.entity.PostRelation;
+import com.tobehome.tobehomeserver.dto.request.PostRelationDTO;
+import com.tobehome.tobehomeserver.repository.PostJpaRepository;
+import com.tobehome.tobehomeserver.repository.PostRelationJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PostRelationService {
+
+    private final PostRelationJpaRepository postRelationRepository;
+    private final PostJpaRepository postRepository;
+
+    @Transactional
+    public void addPostRelation(Long interiorPostId, Long productPostId) {
+        Post interiorPost = postRepository.findById(interiorPostId)
+                .orElseThrow(() -> new IllegalArgumentException("인테리어 게시글을 찾을 수 없습니다."));
+
+        Post productPost = postRepository.findById(productPostId)
+                .orElseThrow(() -> new IllegalArgumentException("상품 게시글을 찾을 수 없습니다."));
+
+        PostRelation postRelation = PostRelation.builder()
+                .interiorPost(interiorPost)
+                .productPost(productPost)
+                .build();
+
+        postRelationRepository.save(postRelation);
+    }
+
+    @Transactional(readOnly = true)
+    public List<PostRelationDTO> getRelatedPosts(Long interiorPostId) {
+        List<PostRelation> postRelations = postRelationRepository.findByInteriorPostId(interiorPostId);
+        return postRelations.stream()
+                .map(PostRelationDTO::from)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void removePostRelation(Long interiorPostId, Long productPostId) {
+        postRelationRepository.deleteByInteriorPostIdAndProductPostId(interiorPostId, productPostId);
+    }
+}

--- a/tobehomeserver/src/main/resources/application.yml
+++ b/tobehomeserver/src/main/resources/application.yml
@@ -1,9 +1,15 @@
 spring:
+#  datasource:
+#    url: jdbc:h2:tcp://localhost/~/tobehomeserver
+#    username: sa
+#    password:
+#    driver-class-name: org.h2.Driver
+
   datasource:
-    url: jdbc:h2:tcp://localhost/~/tobehomeserver
-    username: sa
-    password:
-    driver-class-name: org.h2.Driver
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://${database-host}:3306/tobehome?createDatabaseIfNotExist=true
+    username: root
+    password: ${database-password}
 
   jpa:
     hibernate:


### PR DESCRIPTION
## Description

- 상품 게시글과 인테리어 게시글 간 연관관계 입니다.


## Test

- 연관관계 설정(정상적인 경우)
<img width="773" alt="image" src="https://github.com/GDSC-CAU/ToHome-BE/assets/102952855/a3c4e770-4d36-434d-b394-8e414bcb4d9e">

post table에 값이 이렇게 존재할 때,
<img width="841" alt="image" src="https://github.com/GDSC-CAU/ToHome-BE/assets/102952855/ddf71093-4781-46c3-a75a-d0ca92076d72">


- 연관관계 설정(없는 게시글 등 잘못된 정보)
<img width="832" alt="image" src="https://github.com/GDSC-CAU/ToHome-BE/assets/102952855/7f14788d-7dab-40c1-8ed7-2f75025fa548">


- 인테리어 게시글에 대한 연관관계 정보 불러오기
<img width="865" alt="image" src="https://github.com/GDSC-CAU/ToHome-BE/assets/102952855/0dda1935-28f7-4c5e-a371-85e4944b855a">


- 연관관계 삭제
<img width="808" alt="image" src="https://github.com/GDSC-CAU/ToHome-BE/assets/102952855/da4251eb-4c49-49af-862b-be49013b37df">